### PR TITLE
Add general random class

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reside-ic/random",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "description": "Random numbers",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export {Random} from "./random";
 export {RngState} from "./state";
 export {RngStateBuiltin} from "./state-builtin";
 export {RngStateObserved} from "./state-observed";
@@ -6,4 +7,4 @@ export {RngStateReplay} from "./state-replay";
 export {binomial} from "./binomial";
 export {exponential, randomExponential} from "./exponential";
 export {normal, randomNormal} from "./normal";
-export {uniform} from "./uniform";
+export {randomUniform, uniform} from "./uniform";

--- a/src/random.ts
+++ b/src/random.ts
@@ -1,0 +1,47 @@
+import {RngState} from "./state";
+
+import {binomial} from "./binomial";
+import {exponential, randomExponential} from "./exponential";
+import {normal, randomNormal} from "./normal";
+import {randomUniform, uniform} from "./uniform";
+
+export class Random {
+    public readonly state: RngState;
+
+    constructor(state: RngState) {
+        this.state = state;
+    }
+
+    public clone() {
+        return new Random(this.state.clone());
+    }
+
+    public randomExponential() {
+        return randomExponential(this.state);
+    }
+
+    public randomNormal() {
+        return randomNormal(this.state);
+    }
+
+    public randomUniform() {
+        return randomUniform(this.state);
+    }
+
+    public binomial(n: number, p: number) {
+        return binomial(this.state, n, p);
+    }
+
+    public exponential(rate: number) {
+        return exponential(this.state, rate);
+    }
+
+    public normal(mean: number, sd: number) {
+        return normal(this.state, mean, sd);
+    }
+
+    public uniform(min: number, max: number) {
+        return uniform(this.state, min, max);
+    }
+
+}

--- a/src/random.ts
+++ b/src/random.ts
@@ -1,10 +1,10 @@
-import {RngState} from "./state";
+import { RngState } from "./state";
 
-import {binomial} from "./binomial";
-import {exponential, randomExponential} from "./exponential";
-import {normal, randomNormal} from "./normal";
-import {poisson} from "./poisson";
-import {randomUniform, uniform} from "./uniform";
+import { binomial } from "./binomial";
+import { exponential, randomExponential } from "./exponential";
+import { normal, randomNormal } from "./normal";
+import { poisson } from "./poisson";
+import { randomUniform, uniform } from "./uniform";
 
 /**
  * Generate random numbers. This provides a single object that can be
@@ -67,6 +67,13 @@ export class Random {
      */
     public normal(mean: number, sd: number) {
         return normal(this.state, mean, sd);
+    }
+
+    /** Generate a Poisson distributed random number ({@link poisson})
+     * @param lambda The mean of the distribution
+     */
+    public poisson(lambda: number) {
+        return poisson(this.state, lambda);
     }
 
     /** Generate a uniformly distributed random number ({@link uniform})

--- a/src/random.ts
+++ b/src/random.ts
@@ -3,43 +3,76 @@ import {RngState} from "./state";
 import {binomial} from "./binomial";
 import {exponential, randomExponential} from "./exponential";
 import {normal, randomNormal} from "./normal";
+import {poisson} from "./poisson";
 import {randomUniform, uniform} from "./uniform";
 
+/**
+ * Generate random numbers. This provides a single object that can be
+ * passed around to generate numbers from all distributions supported
+ * by the package, as well as the state required to generate the
+ * numbers from.
+ */
 export class Random {
+    /** The internal random number state, which is updated by calls to
+     * any of the distribution functions.
+     */
     public readonly state: RngState;
 
+    /** An initialised random number state
+     */
     constructor(state: RngState) {
         this.state = state;
     }
 
-    public clone() {
-        return new Random(this.state.clone());
-    }
-
+    /** Generate a standard exponential random number Exponential(1)
+     * ({@link randomExponential})
+     */
     public randomExponential() {
         return randomExponential(this.state);
     }
 
+    /** Generate a standard normal random number N(0, 1) ({@link
+     * randomNormal})
+     */
     public randomNormal() {
         return randomNormal(this.state);
     }
 
+    /** Generate a standard uniform random number U(0, 1) ({@link
+     * randomUniform})
+     */
     public randomUniform() {
         return randomUniform(this.state);
     }
 
+    /** Generate a binomially distributed random number ({@link binomial})
+     * @param n number of trials
+     * @param p per-traial probability of success
+     */
     public binomial(n: number, p: number) {
         return binomial(this.state, n, p);
     }
 
+    /** Generate an exponentially distributed random number
+     * ({@link exponential})
+     * @param rate The rate of the process
+     */
     public exponential(rate: number) {
         return exponential(this.state, rate);
     }
 
+    /** Generate an normally distributed random number ({@link normal})
+     * @param mean The mean of the distribution
+     * @param sd The standard deviation of the distribution
+     */
     public normal(mean: number, sd: number) {
         return normal(this.state, mean, sd);
     }
 
+    /** Generate a uniformly distributed random number ({@link uniform})
+     * @param min Minimum value of the distribution
+     * @param max Max value of the distribution
+     */
     public uniform(min: number, max: number) {
         return uniform(this.state, min, max);
     }

--- a/test/random.test.ts
+++ b/test/random.test.ts
@@ -1,0 +1,47 @@
+import { Random } from "../src/random";
+import { RngStateObserved } from "../src/state-observed";
+
+import { binomial } from "../src/binomial";
+import { exponential, randomExponential } from "../src/exponential";
+import { normal, randomNormal } from "../src/normal";
+import { poisson } from "../src/poisson";
+import { randomUniform, uniform } from "../src/uniform";
+
+import { repeat } from "./helpers";
+
+describe("draws from the object are the same as free functions", () => {
+    const state = new RngStateObserved();
+    const random = new Random(state);
+    const replay = state.replay();
+
+    it("produces the same binomial draws", () => {
+        expect(repeat(() => random.binomial(4, 0.3), 10)).toEqual(
+            repeat(() => binomial(replay, 4, 0.3), 10));
+    });
+
+    it("produces the same exponential draws", () => {
+        expect(repeat(() => random.exponential(0.7), 10)).toEqual(
+            repeat(() => exponential(replay, 0.7), 10));
+        expect(repeat(() => random.randomExponential(), 10)).toEqual(
+            repeat(() => randomExponential(replay), 10));
+    });
+
+    it("produces the same normal draws", () => {
+        expect(repeat(() => random.normal(-5, 0.2), 10)).toEqual(
+            repeat(() => normal(replay, -5, 0.2), 10));
+        expect(repeat(() => random.randomNormal(), 10)).toEqual(
+            repeat(() => randomNormal(replay), 10));
+    });
+
+    it("produces the same poisson draws", () => {
+        expect(repeat(() => random.poisson(2.8), 10)).toEqual(
+            repeat(() => poisson(replay, 2.8), 10));
+    });
+
+    it("produces the same uniform draws", () => {
+        expect(repeat(() => random.uniform(-2.1, 3.5), 10)).toEqual(
+            repeat(() => uniform(replay, -2.1, 3.5), 10));
+        expect(repeat(() => random.randomUniform(), 10)).toEqual(
+            repeat(() => randomUniform(replay), 10));
+    });
+});


### PR DESCRIPTION
This will be useful from the context of an odin model where we need to pass in something that can generate random numbers rather than import the module directly - we do this with the general math support already.

~Merge after #3 as it includes those commits~