### PR TITLE
Observable and replayable state

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reside-ic/random",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "description": "Random numbers",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 export {RngState} from "./state";
 export {RngStateBuiltin} from "./state-builtin";
+export {RngStateObserved} from "./state-observed";
+export {RngStateReplay} from "./state-replay";
 
 export {binomial} from "./binomial";
 export {exponential, randomExponential} from "./exponential";

--- a/src/state-observed.ts
+++ b/src/state-observed.ts
@@ -1,0 +1,37 @@
+import {RngState} from "./state";
+import {RngStateBuiltin} from "./state-builtin";
+import {RngStateReplay} from "./state-replay";
+
+export class RngStateObserved extends RngState {
+    private readonly _state: RngState;
+    private readonly _values: number[]
+
+    constructor(state?: RngState) {
+        super();
+        if (state === undefined) {
+            state = new RngStateBuiltin();
+        }
+        this._state = state;
+        this._values = [];
+    }
+
+    public random() {
+        const ret = this._state.random();
+        this._values.push(ret);
+        return ret;
+    }
+
+    public clone(this: RngStateObserved) {
+        const ret = new RngStateObserved(this._state.clone());
+        ret._values.concat(this._values);
+        return ret;
+    }
+
+    public replay() {
+        return new RngStateReplay(this._values);
+    }
+
+    public length() {
+        return this._values.length;
+    }
+}

--- a/src/state-observed.ts
+++ b/src/state-observed.ts
@@ -6,6 +6,10 @@ export class RngStateObserved extends RngState {
     private readonly _state: RngState;
     private readonly _values: number[]
 
+    /**
+     * Optionally, a random number state - if not given we default
+     * construct the the builtin state {@link RngStateBuiltin}.
+     */
     constructor(state?: RngState) {
         super();
         if (state === undefined) {
@@ -21,17 +25,25 @@ export class RngStateObserved extends RngState {
         return ret;
     }
 
-    public clone(this: RngStateObserved) {
-        const ret = new RngStateObserved(this._state.clone());
-        ret._values.concat(this._values);
-        return ret;
-    }
-
+    /**
+     * Create a new {@link RngStateReplay} random number state that
+     * will replay the values from this generator.
+     */
     public replay() {
         return new RngStateReplay(this._values);
     }
 
+    /**
+     * The number of random number draws available to replay.
+     */
     public length() {
         return this._values.length;
+    }
+
+    /**
+     * The array of values drawn by this generator
+     */
+    public values(): readonly number[] {
+        return this._values;
     }
 }

--- a/src/state-observed.ts
+++ b/src/state-observed.ts
@@ -4,7 +4,7 @@ import {RngStateReplay} from "./state-replay";
 
 export class RngStateObserved extends RngState {
     private readonly _state: RngState;
-    private readonly _values: number[]
+    private readonly _values: number[];
 
     /**
      * Optionally, a random number state - if not given we default

--- a/src/state-replay.ts
+++ b/src/state-replay.ts
@@ -2,11 +2,14 @@ import {RngState} from "./state";
 
 /**
  * A non-random random number state, where the stream is replayed from
- * some set of provided numbers.
+ * some set of provided numbers. Typically created from {@link
+ * RngStateObserved.replay}, in which case generating more draws from
+ * the original source will increase the number available in the
+ * replayable state.
  */
 export class RngStateReplay extends RngState {
     private _i: number;
-    private _values: number[];
+    private readonly _values: readonly number[];
 
     /** @param values The values that the state will return. */
     constructor(values: number[]) {
@@ -23,6 +26,10 @@ export class RngStateReplay extends RngState {
         return ret;
     }
 
+    /**
+     * Number of draws left in the object before we run out of state to
+     * replay
+     */
     public length() {
         return this._values.length - this._i;
     }

--- a/src/state-replay.ts
+++ b/src/state-replay.ts
@@ -1,0 +1,35 @@
+import {RngState} from "./state";
+
+/**
+ * A non-random random number state, where the stream is replayed from
+ * some set of provided numbers.
+ */
+export class RngStateReplay extends RngState {
+    private _i: number;
+    private _values: number[];
+
+    /** @param values The values that the state will return. */
+    constructor(values: number[]) {
+        super();
+        this._i = 0;
+        this._values = values;
+    }
+
+    public random() {
+        const ret = this._values[this._i++];
+        if (this._i > this._values.length) {
+            throw Error("Exhausted stream");
+        }
+        return ret;
+    }
+
+    public clone(this: RngStateReplay) {
+        const ret = new RngStateReplay(this._values);
+        ret._i = this._i;
+        return ret;
+    }
+
+    public length() {
+        return this._values.length - i;
+    }
+}

--- a/src/state-replay.ts
+++ b/src/state-replay.ts
@@ -23,13 +23,7 @@ export class RngStateReplay extends RngState {
         return ret;
     }
 
-    public clone(this: RngStateReplay) {
-        const ret = new RngStateReplay(this._values);
-        ret._i = this._i;
-        return ret;
-    }
-
     public length() {
-        return this._values.length - i;
+        return this._values.length - this._i;
     }
 }

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -1,0 +1,55 @@
+import {RngStateBuiltin} from "../src/state-builtin";
+import {RngStateObserved} from "../src/state-observed";
+import {RngStateReplay} from "../src/state-replay";
+
+import {randomNormal} from "../src/normal";
+
+describe("Can observe random state", () => {
+    it("Keeps track of the numbers as they're drawn", () => {
+        const s = new RngStateObserved();
+        expect(s.length()).toBe(0);
+        expect(s.values()).toEqual([]);
+        s.random();
+        expect(s.length()).toBe(1);
+        randomNormal(s);
+        expect(s.length()).toBe(3);
+        expect(s.values().length).toBe(3);
+    });
+
+    it("Can be replayed", () => {
+        const s1 = new RngStateObserved();
+        const s2 = s1.replay();
+        expect(s2.length()).toBe(0);
+
+        const r = [];
+        const n = 5;
+        for (let i = 0; i < 5; ++i) {
+            r.push(randomNormal(s1));
+        }
+
+        expect(s1.length()).toBe(n * 2);
+        expect(s2.length()).toBe(n * 2);
+        expect(randomNormal(s2)).toBe(r[0]);
+        expect(s2.length()).toBe(n * 2 - 2);
+        for (let i = 1; i < r.length; ++i) {
+            expect(randomNormal(s2)).toBe(r[i]);
+        }
+        expect(() => s2.random()).toThrow("Exhausted stream");
+    });
+
+    it("Can observe a specialised rng state", () => {
+        const s1 = new RngStateObserved();
+        const u1 = s1.random();
+        const s2 = new RngStateObserved(s1);
+        const s3 = new RngStateObserved(s1.replay());
+        expect(s1.length()).toBe(1);
+        expect(s2.length()).toBe(0);
+        const u2 = s1.random();
+        const u3 = s2.random();
+        expect(s1.values()).toEqual([u1, u2, u3]);
+        expect(s2.values()).toEqual([u3]);
+        expect(s3.random()).toBe(u1);
+        expect(s3.random()).toBe(u2);
+        expect(s3.random()).toBe(u3);
+    });
+});


### PR DESCRIPTION
This PR allows RNG state to be observed and replayed, which will be useful for tests in the absence of the default stream being seedable.

The basic idea is to store all calls through `random()` in an array and then allow creation of another object confirming to our RngState class that will replay that state exactly. This is potentially slightly more useful than just being able to run things with the same seed tbh