### PR TITLE
mrc-3812: seedable RNG

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@
 
 Random number distributions in JavaScript
 
+Random numbers are slippery things, particularly if you want to use them. This package provides a slightly different take on random number generation to many other similar javascript packages:
+
+**We focus on access to distributions where the expectation is that subsequent calls may use different parameters**. Many packages focus on efficient generation of numbers from a single distribution (e.g., a binomial distribution with fixed `n` and `p`) but we assume that each call to generate binomial may have a different `n` and `p` and so don't try and be clever about caching.
+
+**We include different underlying generators, and a simple interface that can adapt to new generators**. We provide a abstract `RngState` class and several different concrete versions of this.
+
+The distribution support is curently poor (binomial, exponential, normal, Poisson and uniform) but will expand this as we need them. We try and reference the underlying papers clearly so that these algorithms are as clear as possible.
+
 ## Licence
 
 MIT © Imperial College of Science, Technology and Medicine

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@reside-ic/random",
-    "version": "0.0.1",
+    "version": "0.0.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@reside-ic/random",
-            "version": "0.0.1",
+            "version": "0.0.4",
             "license": "MIT",
             "dependencies": {
                 "ieee745gamma": "^1.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
             },
             "devDependencies": {
                 "@types/jest": "^27.5.1",
+                "alea": "^1.0.1",
                 "jest": "^28.0.0",
                 "ts-jest": "^28.0.0",
                 "ts-loader": "^9.3.0",
@@ -1405,6 +1406,12 @@
             "peerDependencies": {
                 "ajv": "^6.9.1"
             }
+        },
+        "node_modules/alea": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/alea/-/alea-1.0.1.tgz",
+            "integrity": "sha512-QU+wv+ziDXaMxRdsQg/aH7sVfWdhKps5YP97IIwFkHCsbDZA3k87JXoZ5/iuemf4ntytzIWeScrRpae8+lDrXA==",
+            "dev": true
         },
         "node_modules/ansi-escapes": {
             "version": "4.3.2",
@@ -6198,6 +6205,12 @@
             "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
             "dev": true,
             "requires": {}
+        },
+        "alea": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/alea/-/alea-1.0.1.tgz",
+            "integrity": "sha512-QU+wv+ziDXaMxRdsQg/aH7sVfWdhKps5YP97IIwFkHCsbDZA3k87JXoZ5/iuemf4ntytzIWeScrRpae8+lDrXA==",
+            "dev": true
         },
         "ansi-escapes": {
             "version": "4.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4324,9 +4324,9 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.14.1",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.1.tgz",
-            "integrity": "sha512-+ahUAE+iheqBTDxXhTisdA8hgvbEG1hHOQ9xmNjeUJSoi6DU/gMrKNcfZjHkyY6Alnuyc+ikYJaxxfHkT3+WuQ==",
+            "version": "5.15.1",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.1.tgz",
+            "integrity": "sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.2",
@@ -8400,9 +8400,9 @@
             }
         },
         "terser": {
-            "version": "5.14.1",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.1.tgz",
-            "integrity": "sha512-+ahUAE+iheqBTDxXhTisdA8hgvbEG1hHOQ9xmNjeUJSoi6DU/gMrKNcfZjHkyY6Alnuyc+ikYJaxxfHkT3+WuQ==",
+            "version": "5.15.1",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.1.tgz",
+            "integrity": "sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw==",
             "dev": true,
             "requires": {
                 "@jridgewell/source-map": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "homepage": "https://github.com/reside-ic/random-js#readme",
     "devDependencies": {
         "@types/jest": "^27.5.1",
+        "alea": "^1.0.1",
         "jest": "^28.0.0",
         "ts-jest": "^28.0.0",
         "ts-loader": "^9.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reside-ic/random",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "description": "Random numbers",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export {Random} from "./random";
 export {RngState} from "./state";
+export {RngStateAlea} from "./state-alea";
 export {RngStateBuiltin} from "./state-builtin";
 export {RngStateObserved} from "./state-observed";
 export {RngStateReplay} from "./state-replay";

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,4 +8,5 @@ export {RngStateReplay} from "./state-replay";
 export {binomial} from "./binomial";
 export {exponential, randomExponential} from "./exponential";
 export {normal, randomNormal} from "./normal";
+export {poisson} from "./poisson";
 export {randomUniform, uniform} from "./uniform";

--- a/src/state-alea.ts
+++ b/src/state-alea.ts
@@ -86,7 +86,7 @@ export class RngStateAlea extends RngState {
      *
      * @param state A state extracted from a previously initialised
      * copy of an `RngStateAlea` generator; will be a length 4
-     * array. If given, then sed must be `null`.
+     * array. If given, then seed must be `null`.
      */
     constructor(seed: any = null, state?: number[]) {
         super();

--- a/src/state-alea.ts
+++ b/src/state-alea.ts
@@ -1,0 +1,112 @@
+import { RngState } from "./state";
+
+// Two reference implementations:
+//
+// https://github.com/macmcmeans/aleaPRNG/blob/master/aleaPRNG-1.1.js
+// https://github.com/coverslide/node-alea/blob/master/alea.js
+//
+// The original seems to have dropped off the internet, and I can't
+// see a simple impementation with types. As usual, most of the
+// complication is in the initialisation, which uses another prng or
+// streaming hash function.
+
+const TWO_POS_32 = 0x100000000; // 2^32
+const TWO_NEG_32 = 2.3283064365386963e-10; // 2^-32
+
+export function masher() {
+    let n = 0xefc8249d;
+    return (data: string): number => {
+        for (let i = 0; i < data.length; i++) {
+            n += data.charCodeAt(i);
+            let h = 0.02519603282416938 * n;
+            n = h >>> 0;
+            h -= n;
+            h *= n;
+            n = h >>> 0;
+            h -= n;
+            n += h * TWO_POS_32;
+        }
+        return (n >>> 0) * TWO_NEG_32;
+    };
+}
+
+function aleaInitialState(seed: any[]): number[] {
+    if (seed.length === 0) {
+        seed = [Math.random()];
+    }
+    const mash = masher();
+    let s0 = mash(" ");
+    let s1 = mash(" ");
+    let s2 = mash(" ");
+    const c = 1;
+
+    seed.forEach((el) => {
+        const s = el.toString();
+        s0 -= mash(s);
+        if (s0 < 0) {
+            s0 += 1;
+        }
+
+        s1 -= mash(s);
+        if (s1 < 0) {
+            s1 += 1;
+        }
+
+        s2 -= mash(s);
+        if (s2 < 0) {
+            s2 += 1;
+        }
+    });
+
+    return [s0, s1, s2, c];
+}
+
+export class RngStateAlea extends RngState {
+    // The compiler can't work out that these are definitely assigned,
+    // but they are, via setState() (eventually).
+    private s0!: number;
+    private s1!: number;
+    private s2!: number;
+    private c!: number;
+
+    constructor(seed: any[] = [], state?: number[]) {
+        super();
+        const hasSeed = seed.length > 0;
+        const hasInitialState = state !== undefined;
+        if (hasSeed && hasInitialState) {
+            throw Error("Can't provide both initial seed and state");
+        }
+        if (hasInitialState) {
+            this.setState(state);
+        } else {
+            this.setSeed(seed);
+        }
+    }
+
+    public random() {
+        const t = 2091639 * this.s0 + this.c * TWO_NEG_32;
+        this.s0 = this.s1;
+        this.s1 = this.s2;
+        return this.s2 = t - (this.c = t | 0);
+    }
+
+    public setSeed(seed: any[]) {
+        const state = aleaInitialState(seed);
+        this.setState(state);
+    }
+
+    public getState(): number[] {
+        return [this.s0, this.s1, this.s2, this.c];
+    }
+
+    public setState(state: number[]) {
+        if (state.length !== 4) {
+            throw Error(`Expected state to have length 4 (but was ${state.length})`);
+        }
+
+        this.s0 = state[0];
+        this.s1 = state[1];
+        this.s2 = state[2];
+        this.c = state[3];
+    }
+}

--- a/src/state.ts
+++ b/src/state.ts
@@ -16,4 +16,12 @@ export abstract class RngState {
     public setSeed(seed: any) {
         throw Error("This generator cannot be seeded (really!)");
     }
+    /** Get the entire internal state of a generator */
+    public getState(): any {
+        throw Error("This generator cannot return its state");
+    }
+    /** Replace the entire internal state of a generator */
+    public setState(state: any) {
+        throw Error("This generator set its state");
+    }
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -3,6 +3,21 @@
  * functions (e.g., {@link normal}. The base class does not implement
  * any draws though, so use a specialisation such as {@link
  * RngStateBuiltin} or create a less terrible one.
+ *
+ * We provide several concrete state clases that can be used:
+ *
+ * * {@link RngStateBuiltin}: Uses `Math.random()` and can't be
+ *   seeded, saved, restored and has dubious statistical and
+ *   predictibility properties
+ *
+ * * {@link RngStateAlea}: Uses the "Alea" algorithm, and can be
+ *   seeded, saved, restored and has better statistical properties
+ *   (but is still predictable)
+ *
+ * * {@link RngStateObserved}: Wraps any `RngState`-implementing class
+ *   and allows observation of the draws, useful for testing.
+ *
+ * * {@link RngStateReplay}: Replays the state of any observed state
  */
 export abstract class RngState {
     /** Generate a single random number on the interval [0, 1],

--- a/test/generator.test.ts
+++ b/test/generator.test.ts
@@ -12,4 +12,14 @@ describe("Builtin generator", () => {
         expect(() => state.setSeed(1))
             .toThrow("This generator cannot be seeded");
     });
+
+    it("Cannot return state", () => {
+        expect(() => state.getState())
+            .toThrow("This generator cannot return its state");
+    });
+
+    it("Cannot set state", () => {
+        expect(() => state.setState(null))
+            .toThrow("This generator set its state");
+    });
 });

--- a/test/normal.test.ts
+++ b/test/normal.test.ts
@@ -16,7 +16,7 @@ describe("normal random numbers", () => {
     });
 
     it("generates with expected mean and variance", () => {
-        const n = 100000;
+        const n = 200000;
         const res = repeat<number>(() => normal(state, 2, 5), n);
         expect(mean(res)).toApproxEqual(2, 1e-2);
         expect(sd(res)).toApproxEqual(5, 1e-2);

--- a/test/state-alea.test.ts
+++ b/test/state-alea.test.ts
@@ -1,6 +1,8 @@
 import { RngStateAlea, masher } from "../src/state-alea";
 import "./matchers";
 
+const aleaReference = require("alea");
+
 describe("can generate random numbers", () => {
     it("generates known case", () => {
         // just generate two numbers and show they're different and
@@ -58,6 +60,16 @@ describe("can generate random numbers", () => {
         const variance = x2 / n - mean * mean; // E(x^2) - E(x)^2
         expect(mean).toApproxEqual(0.5, 1e-3);
         expect(variance).toApproxEqual(1 / 12, 1e-2);
+    });
+
+    it("agrees with reference implementation", () => {
+        const ref = aleaReference([42]);
+        const state = new RngStateAlea(42);
+        expect(state.getState()).toEqual(ref.exportState());
+        expect(state.random()).toEqual(ref.next());
+        expect(state.random()).toEqual(ref.next());
+        expect(state.random()).toEqual(ref.next());
+        expect(state.getState()).toEqual(ref.exportState());
     });
 });
 

--- a/test/state-alea.test.ts
+++ b/test/state-alea.test.ts
@@ -40,6 +40,8 @@ describe("can generate random numbers", () => {
         const s = new RngStateAlea(0.9398027063099774);
         const state = s.getState();
         expect(state[0]).toBeGreaterThan(0);
+        expect(state[1]).toBeGreaterThan(0);
+        expect(state[2]).toBeGreaterThan(0);
     });
 
     it("generates numbers with the correct distribution", () => {

--- a/test/state-alea.test.ts
+++ b/test/state-alea.test.ts
@@ -5,7 +5,7 @@ describe("can generate random numbers", () => {
     it("generates known case", () => {
         // just generate two numbers and show they're different and
         // that they don't change; this should always just hold.
-        const s = new RngStateAlea([42]);
+        const s = new RngStateAlea(42);
         const u1 = s.random();
         const u2 = s.random();
         expect(u1).toBe(0.6848634963389486);
@@ -19,31 +19,31 @@ describe("can generate random numbers", () => {
     });
 
     it("requires at most one of seed and state to initialise", () => {
-        expect(() => new RngStateAlea([42], [1, 2, 3, 4]))
+        expect(() => new RngStateAlea(42, [1, 2, 3, 4]))
             .toThrow("Can't provide both initial seed and state");
     });
 
     it("requires that state is correct length", () => {
-        expect(() => new RngStateAlea([], [1, 2, 3]))
+        expect(() => new RngStateAlea(null, [1, 2, 3]))
             .toThrow("Expected state to have length 4 (but was 3)");
     });
 
     it("can extract state from generator and seed a new one", () => {
-        const s1 = new RngStateAlea([42]);
+        const s1 = new RngStateAlea(42);
         const x1 = s1.getState();
-        const s2 = new RngStateAlea([], x1);
+        const s2 = new RngStateAlea(null, x1);
         expect(s1.getState()).toEqual(s2.getState());
         expect(s1.random()).toBe(s2.random());
     });
 
     it("can prevent negative values in seed coefficient", () => {
-        const s = new RngStateAlea([0.9398027063099774]);
+        const s = new RngStateAlea(0.9398027063099774);
         const state = s.getState();
         expect(state[0]).toBeGreaterThan(0);
     });
 
     it("generates numbers with the correct distribution", () => {
-        const s = new RngStateAlea([42]);
+        const s = new RngStateAlea(42);
         const n = 1000000;
         let x = 0;
         let x2 = 0;

--- a/test/state-alea.test.ts
+++ b/test/state-alea.test.ts
@@ -1,0 +1,69 @@
+import { RngStateAlea, masher } from "../src/state-alea";
+import "./matchers";
+
+describe("can generate random numbers", () => {
+    it("generates known case", () => {
+        // just generate two numbers and show they're different and
+        // that they don't change; this should always just hold.
+        const s = new RngStateAlea([42]);
+        const u1 = s.random();
+        const u2 = s.random();
+        expect(u1).toBe(0.6848634963389486);
+        expect(u2).toBe(0.5463244677521288);
+    });
+
+    it("generates different values when initialised without args", () => {
+        const s1 = new RngStateAlea();
+        const s2 = new RngStateAlea();
+        expect(s1.random()).not.toEqual(s2.random());
+    });
+
+    it("requires at most one of seed and state to initialise", () => {
+        expect(() => new RngStateAlea([42], [1, 2, 3, 4]))
+            .toThrow("Can't provide both initial seed and state");
+    });
+
+    it("requires that state is correct length", () => {
+        expect(() => new RngStateAlea([], [1, 2, 3]))
+            .toThrow("Expected state to have length 4 (but was 3)");
+    });
+
+    it("can extract state from generator and seed a new one", () => {
+        const s1 = new RngStateAlea([42]);
+        const x1 = s1.getState();
+        const s2 = new RngStateAlea([], x1);
+        expect(s1.getState()).toEqual(s2.getState());
+        expect(s1.random()).toBe(s2.random());
+    });
+
+    it("can prevent negative values in seed coefficient", () => {
+        const s = new RngStateAlea([0.9398027063099774]);
+        const state = s.getState();
+        expect(state[0]).toBeGreaterThan(0);
+    });
+
+    it("generates numbers with the correct distribution", () => {
+        const s = new RngStateAlea([42]);
+        const n = 1000000;
+        let x = 0;
+        let x2 = 0;
+        for (let i = 0; i < n; ++i) {
+            const u = s.random();
+            x += u;
+            x2 += u * u;
+        }
+        const mean = x / n; // E[x]
+        const variance = x2 / n - mean * mean; // E(x^2) - E(x)^2
+        expect(mean).toApproxEqual(0.5, 1e-3);
+        expect(variance).toApproxEqual(1 / 12, 1e-2);
+    });
+});
+
+describe("does the mash", () => {
+    it("does the monster mash", () => {
+        const mash = masher();
+        expect(mash("monster")).toBe(0.6911363429389894);
+        expect(mash("monster")).toBe(0.5563453969080001);
+        expect(mash("monster")).toBe(0.3086991817690432);
+    });
+});


### PR DESCRIPTION
Implements a seedable RNG that we can use to:

* set off with a seed so that results are reproducible
* extract state from before a run so that we can recreate something we have not done yet

Implemented using a js-tuned algorithm, though the original sources are lost to time. See comments for details.

I've expanded the generic RngState interface a little to accommodate the new features.